### PR TITLE
Add configuration options w.r.t smarthost/satellites

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Available variables are listed below, along with default values (see `defaults/m
 Mail configuration type. Should be one of:
 
   - 'internet' for public mail facing server,
-  - 'smarthost' for relay via smarthost, but accept via SMTP, 
+  - 'smarthost' for relay via smarthost, but accept via SMTP,
   - 'satellite' if sending via smarthost (c.f. 'exim_dc_smarthost'), or
-  - 'local' if mail should only be delivered locally. 
+  - 'local' if mail should only be delivered locally.
 
 See Exim documentation for other options.  *(Debian/Ubuntu only)*
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,38 @@ Available variables are listed below, along with default values (see `defaults/m
 
     exim_dc_eximconfig_configtype: internet
 
-(Debian/Ubuntu only) Main configuration type. Should be 'internet' for public mail sending, or 'local' if mail should only be delivered locally. See Exim documentation for other options.
+Mail configuration type. Should be one of:
+
+  - 'internet' for public mail facing server,
+  - 'smarthost' for relay via smarthost, but accept via SMTP, 
+  - 'satellite' if sending via smarthost (c.f. 'exim_dc_smarthost'), or
+  - 'local' if mail should only be delivered locally. 
+
+See Exim documentation for other options.  *(Debian/Ubuntu only)*
+
+    exim_dc_other_hostnames: "{{ansible_hostname}}"
+
+Other hostnames for which this host will accept email.  *(Debian/Ubuntu only)*
+
+    exim_dc_smarthost: ''
+
+Relay mail through a different "smarthost" (or for 'satellite')  *(Debian/Ubuntu only)*
+
+    exim_dc_readhost: ''
+
+Rewrite outgoing mail local machine with this value.  *(Debian/Ubuntu only)*
+
+    exim_dc_hide_mailname: ''
+
+Hide the local mailname in the headers of outgoing messages (or not).  *(Debian/Ubuntu only)*
 
     exim_dc_localdelivery: mail_spool
 
-(Debian/Ubuntu only) Default transport for local mail delivery. Defaults to `mail_spool` if unset.
+Local delivery method.  *(Debian/Ubuntu only)*
 
     exim_primary_hostname: ""
 
-Force a primary server hostname for Exim. Usually you don't need to set this, but if Exim can't reliably determine the FQDN of your server, you can set this and it will ensure Exim uses the correct hostname.
+Force a primary server hostname for Exim. Usually you don't need to set this, but if Exim can't reliably determine the FQDN of your server, you can set this and it will ensure Exim uses the correct hostname.  If empty, the directive will be ignored.
 
 ## Dependencies
 
@@ -32,7 +55,12 @@ None.
 
     - hosts: servers
       roles:
-        - geerlingguy.exim
+      - role: geerlingguy.exim
+        vars:
+          exim_dc_eximconfig_configtype: satellite
+          exim_dc_readhost: 'domain.org'
+          exim_dc_smarthost: 'mail.domain.org'
+          exim_dc_hide_mailname: 'true'
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,25 @@
 ---
-# Main configuration type. Should be 'internet' for public mail sending, or
-# 'local' if mail should only be delivered locally. See Exim documentation for
-# other options.
+# Mail configuration type. Should be one of:
+# - 'internet' for public mail facing server,
+# - 'smarthost' for relay via smarthost, but accept via SMTP, 
+# - 'satellite' if sending via smarthost (c.f. 'exim_dc_smarthost'), or
+# - 'local' if mail should only be delivered locally. 
+# See Exim documentation for other options.
 exim_dc_eximconfig_configtype: internet
 
-# Other exim directives.
+# Other hostnames for which this host will accept email.
+exim_dc_other_hostnames: "{{ansible_hostname}}"
+
+# Relay mail through a different "smarthost" (or for 'satellite')
+exim_dc_smarthost: ''
+
+# Rewrite outgoing mail local machine with this value.
+exim_dc_readhost: ''
+
+# Hide the local mailname in the headers of outgoing messages (or not).
+exim_dc_hide_mailname: ''
+
+# Local delivery method.
 exim_dc_localdelivery: mail_spool
 
 # Set a primary_hostname. If empty, the directive will be ignored.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 # Mail configuration type. Should be one of:
 # - 'internet' for public mail facing server,
-# - 'smarthost' for relay via smarthost, but accept via SMTP, 
+# - 'smarthost' for relay via smarthost, but accept via SMTP,
 # - 'satellite' if sending via smarthost (c.f. 'exim_dc_smarthost'), or
-# - 'local' if mail should only be delivered locally. 
+# - 'local' if mail should only be delivered locally.
 # See Exim documentation for other options.
 exim_dc_eximconfig_configtype: internet
 

--- a/meta/.gitignore
+++ b/meta/.gitignore
@@ -1,0 +1,1 @@
+.galaxy_install_info

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,14 @@
   with_items:
     - regexp: '^dc_eximconfig_configtype'
       line: "dc_eximconfig_configtype='{{ exim_dc_eximconfig_configtype }}'"
+    - regexp: '^dc_other_hostnames'
+      line: "dc_other_hostnames='{{ exim_dc_other_hostnames }}'"
+    - regexp: '^dc_smarthost'
+      line: "dc_smarthost='{{ exim_dc_smarthost }}'"
+    - regexp: '^dc_readhost'
+      line: "dc_readhost='{{ exim_dc_readhost }}'"
+    - regexp: '^dc_hide_mailname'
+      line: "dc_hide_mailname='{{ exim_dc_hide_mailname }}'"
     - regexp: '^dc_localdelivery'
       line: "dc_localdelivery='{{ exim_dc_localdelivery }}'"
   notify: restart exim

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,9 @@
     - regexp: '^dc_localdelivery'
       line: "dc_localdelivery='{{ exim_dc_localdelivery }}'"
   notify: restart exim
-  when: ansible_os_family == 'Debian'
+  when:
+    - ansible_os_family == 'Debian'
+    - not ansible_check_mode
 
 - name: Configure primary_hostname (if set).
   lineinfile:


### PR DESCRIPTION
* Add ability to configure smarthost or satellite installations; added options:
  - exim_dc_smarthost: ''
  - exim_dc_readhost: ''
  - exim_dc_hide_mailname: ''
  - exim_dc_other_hostnames: "{{ansible_hostname}}"
* Must set `dc_other_hostnames` to something otherwise fresh or re-install of exim (on Debian*) will use contents of `/etc/mailname` to populate that field, which breaks satellite mode.
* Update documentation (README.md) to reflect new variables and defaults.
