### PR TITLE
Fix configure primary_hostname (if set) DEPRECATION WARNING

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
     line: "primary_hostname={{ exim_primary_hostname }}"
     state: present
   notify: restart exim
-  when: exim_primary_hostname
+  when: exim_primary_hostname is defined and exim_primary_hostname
 
 - name: Ensure exim is running.
   service: "name={{ exim_daemon }} state=started enabled=yes"


### PR DESCRIPTION
Conditional on primary_hostname with Ansible 2.9.1 raise deprecation warning.
This will fix it.
```
[DEPRECATION WARNING]: evaluating  as a bare variable, this behaviour will go away and you might need to add |bool to
the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in
version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```