### PR TITLE
Added extra options 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,29 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    exim_dc_eximconfig_configtype: internet
-
-(Debian/Ubuntu only) Main configuration type. Should be 'internet' for public mail sending, or 'local' if mail should only be delivered locally. See Exim documentation for other options.
-
-    exim_dc_localdelivery: mail_spool
-
-(Debian/Ubuntu only) Default transport for local mail delivery. Defaults to `mail_spool` if unset.
-
     exim_primary_hostname: ""
 
 Force a primary server hostname for Exim. Usually you don't need to set this, but if Exim can't reliably determine the FQDN of your server, you can set this and it will ensure Exim uses the correct hostname.
+
+### Debian/Ubuntu only
+
+These variables are only for Debian/Ubuntu. See [man 8 update-exim4.conf](https://manpages.debian.org/bullseye/exim4-config/update-exim4.conf.8.en.html#CONFIGURATION_VARIABLES) for more information.
+
+    exim_dc_eximconfig_configtype: internet
+
+Main configuration type. Should be 'internet' for public mail sending, or 'local' if mail should only be delivered locally. See Exim documentation for other options.
+
+    exim_dc_local_interfaces: "127.0.0.1 ; ::1"
+
+List of IP addresses the Exim daemon should listen on. If this is left empty, Exim listens on all interfaces. Defaults to `127.0.0.1 ; ::1` if unset.
+
+    exim_dc_relay_nets: ""
+
+A list of machines for which we serve as smarthost. Please note that 127.0.0.1 and ::1 are always permitted to relay.
+
+    exim_dc_localdelivery: mail_spool
+
+Default transport for local mail delivery. Defaults to `mail_spool` if unset.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,10 @@
 exim_dc_eximconfig_configtype: internet
 
 # Other exim directives.
+exim_dc_local_interfaces: "127.0.0.1 ; ::1"
+
+exim_dc_relay_nets: ""
+
 exim_dc_localdelivery: mail_spool
 
 # Set a primary_hostname. If empty, the directive will be ignored.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,10 @@
       line: "dc_eximconfig_configtype='{{ exim_dc_eximconfig_configtype }}'"
     - regexp: '^dc_localdelivery'
       line: "dc_localdelivery='{{ exim_dc_localdelivery }}'"
+    - regexp: '^dc_local_interfaces'
+      line: "dc_local_interfaces='{{ exim_dc_local_interfaces }}'"
+    - regexp: '^dc_relay_nets'
+      line: "dc_relay_nets='{{ exim_dc_relay_nets }}'"
   notify: restart exim
   when: ansible_os_family == 'Debian'
 


### PR DESCRIPTION
Added extra config options corresponding to Debian options dc_localdelivery and dc_local_interfaces.

My use case was to allow docker containers to use their host as a mail relay.

In the README, moved exim4-config's package options to sub-heading Debian/Ubuntu only.